### PR TITLE
Change default value of setShowBadge to false

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -2756,7 +2756,7 @@ public class FirebasePlugin extends CordovaPlugin {
             channel.setLockscreenVisibility(visibility);
 
             // Badge
-            boolean badge = options.optBoolean("badge", true);
+            boolean badge = options.optBoolean("badge", false);
             Log.d(TAG, "Channel " + id + " - badge=" + badge);
             channel.setShowBadge(badge);
 


### PR DESCRIPTION
This will avoid the created default channel to show badges which you cannot revert.